### PR TITLE
#9 Change tests for Client package

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -17,6 +17,7 @@ limitations under the License.
 package client
 
 import (
+	"errors"
 	"io/ioutil"
 	"log"
 	"os"
@@ -101,6 +102,7 @@ func getInClusterNamespace() string {
 	return string(data)
 }
 
+//
 func ConfigPath(cfgFile string) string {
 	homeDir := "."
 	if dir := os.Getenv("HOME"); dir != "" {
@@ -132,7 +134,7 @@ func NewClient(cfgFile string) (ConfigSet, error) {
 	if err != nil {
 		log.Printf("%s, falling back to in-cluster configuration\n", err)
 		if config, err = rest.InClusterConfig(); err != nil {
-			log.Fatalln("Can't read config file")
+			return ConfigSet{}, errors.New("Can't read config file")
 		}
 		if len(Namespace) == 0 {
 			Namespace = getInClusterNamespace()


### PR DESCRIPTION
@tzununbekov fixed tests for Client package. Please, check it out. There is one change I made for the code. In `ConfigPath` func, I removed fataling, and added return statement that will return err with empty config. Now it is better testible. But maybe this is not how it suppose to work. Please, let me know and I will change it in case needed. 