### PR TITLE
Do not remove orphaned functions in the dry-run client mode

### DIFF
--- a/pkg/resources/service/create_test.go
+++ b/pkg/resources/service/create_test.go
@@ -17,7 +17,7 @@ func TestDryRunDeployment(t *testing.T) {
 	defer func() { Output = os.Stdout }()
 
 	client.Dry = true
-	clientset, err := client.NewClient(client.ConfigPath(""))
+	clientset, err := client.NewClient("../../../testfiles/cfgfile-test.json")
 	require.NoError(t, err)
 
 	service := &Service{Namespace: "my-namespace"}

--- a/pkg/resources/service/yaml-manifest.go
+++ b/pkg/resources/service/yaml-manifest.go
@@ -79,7 +79,7 @@ func (s *Service) DeployFunctions(functions []Service, removeOrphans bool, threa
 		}
 	}
 
-	if removeOrphans {
+	if removeOrphans && !client.Dry {
 		if err := s.removeOrphans(functions, clientset); err != nil {
 			return err
 		}


### PR DESCRIPTION
## Description

This pull requests fixes a bug that caused accessing a cluster in a dry-run client mode.

When the dry-run mode is enabled, `tm` should not attempt to access a cluster. 