### PR TITLE
circleci: use `github-release` for managing releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
           name: Store Service Account
           command: echo $GCLOUD_SERVICE_KEY > ${HOME}/gcloud-service-key.json
       - run:
-          name: Setup credentials 
+          name: Setup credentials
           command: |
             gcloud auth activate-service-account --key-file=${HOME}/gcloud-service-key.json
             gcloud --quiet config set project ${GOOGLE_PROJECT_ID}
@@ -62,14 +62,20 @@ jobs:
       - attach_workspace:
           at: /tmp/artifacts
       - run:
+          name: "Install github-release tool"
+          command: go get github.com/aktau/github-release
+      - run:
           name: "Publish Release on GitHub"
           command: |
-            # Workaround not to trigger build loop by updating tag with artifacts
-            VERSION=$(/tmp/artifacts/tm --version | awk '{print $3}')
-            if [[ $(curl -o /dev/null -sfIw "%{http_code}" https://github.com/triggermesh/tm/releases/download/${VERSION}/tm) -ne 302 ]]; then
-              go get github.com/tcnksm/ghr
-              ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${VERSION} /tmp/artifacts
-            fi
+            # delete the release if it exists (it does not delete the tag, only the github release and associated artifacts)
+            github-release delete -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -t ${CIRCLE_TAG} 2>/dev/null ||:
+            github-release release -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -t ${CIRCLE_TAG} -d "tm ${CIRCLE_TAG}"
+      - run:
+          name: "Upload Release Artifacts"
+          command: |
+            for f in $(find /tmp/artifacts/ -type f); do
+              github-release upload -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -t ${CIRCLE_TAG} -n "$(basename ${f})" -f "${f}"
+            done
 
 workflows:
   version: 2


### PR DESCRIPTION
The `ghr` tools `-delete` argument deletes a release and its git tag in advance if it exists.
The deletion of the tag is likely the reason the build loop is relaunched after the tag is recreated.
Ideally `-delete` should only delete the github release and not perform any operations on the git repo.

In this PR I have replaced `ghr` with the `github-release` tool which is feature rich and does not
delete tags when a release is deleted.

Closes #161 

ref:
 - https://github.com/tcnksm/ghr/blob/master/README.md#options