### PR TITLE
cloudbuild: removed redundant `docker push` step

### DIFF
--- a/cloudbuild-tag.yaml
+++ b/cloudbuild-tag.yaml
@@ -4,6 +4,4 @@ steps:
   env: ['PROJECT_ROOT=github.com/triggermesh/tm']
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build', '-t', 'gcr.io/$PROJECT_ID/tm:$TAG_NAME', '.']
-- name: 'gcr.io/cloud-builders/docker'
-  args: ['push', 'gcr.io/$PROJECT_ID/tm:$TAG_NAME']
-images: ['gcr.io/$PROJECT_ID/tm:$TAG_NAME']
+images: ['gcr.io/$PROJECT_ID/tm']

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,6 +4,4 @@ steps:
   env: ['PROJECT_ROOT=github.com/triggermesh/tm']
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build', '-t', 'gcr.io/$PROJECT_ID/tm:$REVISION_ID', '-t', 'gcr.io/$PROJECT_ID/tm:latest', '.']
-- name: 'gcr.io/cloud-builders/docker'
-  args: ['push', 'gcr.io/$PROJECT_ID/tm:$REVISION_ID']
 images: ['gcr.io/$PROJECT_ID/tm']


### PR DESCRIPTION
cloudbuild will push all tags of `image` `gcr.io/$PROJECT_ID/tm`