### PR TITLE
ci: use `github.com/meterup/github-release`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
           at: /tmp/artifacts
       - run:
           name: "Install github-release tool"
-          command: go get github.com/aktau/github-release
+          command: go get github.com/meterup/github-release
       - run:
           name: "Publish Release on GitHub"
           command: |


### PR DESCRIPTION
API used by github.com/aktau/github-release will be deprecated in April. The project has not being maintained by the original developer. The github.com/meterup/github-release fork removes usage of the deprecated apis