### PR TITLE
build: make dockerfile buildable by users

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,23 @@
+# Top level files and directories
+/.circleci/
+/.dockerignore
+/.git/
+/cloudbuild.yaml
+/doc/
+/Dockerfile
+/scripts/
+/testfiles/
+
+# Patterns
+**/tm-coverage.html
+**/tm-unit-tests.xml
+**/README.md
+**/*_test.go
+**/.gitignore
+**/c.out
+
+# Binaries
+/tm
+/tm-darwin-amd64
+/tm-linux-amd64
+/tm-windows-amd64.exe

--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,2 @@
+#!include:.dockerignore
+!Dockerfile

--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,16 @@
-## Continuous integration
-c.out
-tm-coverage.html
-tm-unit-tests.xml
+# Continuous integration
+**/c.out
+**/tm-coverage.html
+**/tm-unit-tests.xml
+
+# Editors and IDEs
+*.swp
+*~
+/*.sublime-project
+/.vscode/
 
 # Build artifacts
 tm
-tm-linux-amd64
 tm-darwin-amd64
+tm-linux-amd64
 tm-windows-amd64.exe
-
-# Editors and IDES
-.vscode
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,24 @@
+FROM golang:1.14 AS build
+
+ENV CGO_ENABLED=0
+ENV GOOS=linux
+ENV GOARCH=amd64
+
+WORKDIR /tm
+
+COPY go.mod go.sum /tm/
+RUN go mod download
+
+ARG GIT_TAG
+ENV GIT_TAG=${GIT_TAG:-unknown}
+
+COPY . .
+RUN make install
+
 FROM debian:stable-slim
 
 RUN apt-get update && \
-    apt-get -y install ca-certificates
+    apt-get install --no-install-recommends --no-install-suggests -y ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
 
-ADD gopath/bin/tm /usr/bin/tm
+COPY --from=build /go/bin/tm /bin/tm

--- a/cloudbuild-tag.yaml
+++ b/cloudbuild-tag.yaml
@@ -1,7 +1,0 @@
-steps:
-- name: 'gcr.io/cloud-builders/go:debian'
-  args: ['install', '.']
-  env: ['PROJECT_ROOT=github.com/triggermesh/tm']
-- name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '-t', 'gcr.io/$PROJECT_ID/tm:$TAG_NAME', '.']
-images: ['gcr.io/$PROJECT_ID/tm']

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,7 +1,24 @@
 steps:
-- name: 'gcr.io/cloud-builders/go:debian'
-  args: ['install', '.']
-  env: ['PROJECT_ROOT=github.com/triggermesh/tm']
-- name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '-t', 'gcr.io/$PROJECT_ID/tm:$REVISION_ID', '-t', 'gcr.io/$PROJECT_ID/tm:latest', '.']
-images: ['gcr.io/$PROJECT_ID/tm']
+- name: 'gcr.io/kaniko-project/executor:latest'
+  args:
+  - --dockerfile=Dockerfile
+  - --destination=gcr.io/$PROJECT_ID/tm:${COMMIT_SHA}
+  - --destination=gcr.io/$PROJECT_ID/tm:${_KANIKO_IMAGE_TAG}
+  - --cache-repo=gcr.io/$PROJECT_ID/tm/cache
+  - --build-arg=GIT_TAG=${TAG_NAME}
+  - --no-push=${_KANIKO_NO_PUSH}
+  - --cache=${_KANIKO_USE_BUILD_CACHE}
+  - ${_KANIKO_EXTRA_ARGS}
+  waitFor: ['-']
+
+substitutions:
+  _KANIKO_IMAGE_TAG: "latest"
+  _KANIKO_NO_PUSH: "false"
+  _KANIKO_USE_BUILD_CACHE: "true"
+  _KANIKO_EXTRA_ARGS: ""
+
+options:
+  substitution_option: 'ALLOW_LOOSE'
+
+tags:
+  - tm


### PR DESCRIPTION
- rewrite of the dockerfile so that users can build the docker image
using it, closes #165
- unified the cloudbuild.yaml, closes #166 #167 
- optimized docker/cloudbuild build context
- use of kaniko to improve fs cache hits on gcloud