### PR TITLE
Standardize CI Pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,101 +1,147 @@
-version: 2
+version: 2.1
+
+orbs:
+  go: circleci/go@1.1.1
+  gcp-cli: circleci/gcp-cli@1.8.4
+
 jobs:
-  build:
-    working_directory: /go/src/github.com/triggermesh/tm
-    docker:
-      - image: circleci/golang
+  checkout:
+    executor:
+      name: go/default
+      tag: '1.14'
     steps:
-      - run:
-          name: Install gcloud SDK
-          command: |
-            echo "deb http://packages.cloud.google.com/apt cloud-sdk-stretch main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
-            curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
-            sudo apt-get update -y
-            sudo apt-get install google-cloud-sdk -y
-            go get -u golang.org/x/lint/golint
-            go get -u github.com/Masterminds/glide
-      - run:
-          name: Store Service Account
-          command: echo $GCLOUD_SERVICE_KEY > ${HOME}/gcloud-service-key.json
-      - run:
-          name: Setup credentials
-          command: |
-            gcloud auth activate-service-account --key-file=${HOME}/gcloud-service-key.json
-            gcloud --quiet config set project ${GOOGLE_PROJECT_ID}
-            gcloud --quiet config set compute/zone ${GOOGLE_COMPUTE_ZONE}
-            gcloud --quiet container clusters get-credentials ${GOOGLE_CLUSTER_NAME}
-            mkdir -p ${HOME}/.tm/
-            cp ${HOME}/.kube/config ${HOME}/.tm/config.json
       - checkout
-      - restore_cache:
-          keys:
-            - v1-pkg-cache
+      - go/mod-download-cached
+      - persist_to_workspace:
+          root: ~/
+          paths:
+            - go
+            - project
+
+  build:
+    executor:
+      name: go/default
+      tag: '1.14'
+    steps:
+      - attach_workspace:
+          at: ~/
       - run:
-          name: Run lint
-          command: make lint
+          name: Building package
+          command: make build
+      - gcp-cli/install
+      - gcp-cli/initialize
       - run:
-          name: Run fmt-test
+          name: Building docker image
+          command: gcloud builds submit --config cloudbuild.yaml --substitutions _KANIKO_NO_PUSH=true
+
+  test:
+    executor:
+      name: go/default
+      tag: '1.14'
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: Running fmt-test
           command: make fmt-test
       - run:
-          name: Run vet
+          name: Running vet
           command: make vet
+      - gcp-cli/install
+      - gcp-cli/initialize
       - run:
-          name: Run unit tests
-          no_output_timeout: 15m
+          name: Fetching cluster credentials
+          command: gcloud container clusters get-credentials ${GOOGLE_CLUSTER_NAME}
+      - run:
+          name: Creating tm config file
+          command: mkdir -p ~/.tm/ && cp ~/.kube/config ~/.tm/config.json
+      - run:
+          name: Running unit tests
           command: mkdir -p ${OUTPUT_DIR} && make test
           environment:
             OUTPUT_DIR: /tmp/test-results/
       - store_test_results:
-         path: /tmp/test-results/
-      - save_cache:
-          key: v1-pkg-cache
-          paths:
-            - "/go/pkg"
+          path: /tmp/test-results/
+      - run:
+          name: Generating coverage report
+          command: mkdir -p ${OUTPUT_DIR} && make coverage
+          environment:
+            OUTPUT_DIR: /tmp/artifacts/
+      - store_artifacts:
+          path: /tmp/artifacts/
+
+  publish:
+    executor:
+      name: gcp-cli/google
+    steps:
+      - attach_workspace:
+          at: ~/
+      - gcp-cli/initialize
+      - run:
+          name: Publishing docker image
+          command: gcloud builds submit --config cloudbuild.yaml --substitutions COMMIT_SHA=${CIRCLE_SHA1},TAG_NAME=${CIRCLE_TAG:-$(git describe --tags --always)},_KANIKO_IMAGE_TAG=${CIRCLE_TAG:-latest}
 
   release:
-    docker:
-      - image: circleci/golang
+    executor:
+      name: go/default
+      tag: '1.14'
     steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - v1-pkg-cache
+      - attach_workspace:
+          at: ~/
       - run:
-          name: Build binaries
+          name: Building release packages
           command: make release
           environment:
             DIST_DIR: /tmp/dist/
             GIT_TAG: ${CIRCLE_TAG}
       - run:
-          name: "Install github-release tool"
+          name: Installing github-release
           command: go get github.com/meterup/github-release
       - run:
-          name: "Publish Release on GitHub"
+          name: Creating github release
           command: |
-            # delete the release if it exists (it does not delete the tag, only the github release and associated artifacts)
+            PRE_RELEASE=${CIRCLE_TAG/${CIRCLE_TAG%-rc[0-9]*}/}
             github-release delete -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -t ${CIRCLE_TAG} 2>/dev/null ||:
-            github-release release -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -t ${CIRCLE_TAG} -d "tm ${CIRCLE_TAG}"
-      - run:
-          name: "Upload Release Artifacts"
-          command: |
-            for f in $(find /tmp/artifacts/ -type f); do
-              github-release upload -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -t ${CIRCLE_TAG} -n "$(basename ${f})" -f "${f}"
-            done
+            ./scripts/release-notes.sh ${CIRCLE_TAG} | github-release release ${PRE_RELEASE:+-p} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -t ${CIRCLE_TAG} -d -
+            for f in $(find /tmp/dist -type f); do github-release upload -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -t ${CIRCLE_TAG} -n $(basename ${f}) -f ${f} ; done
 
 workflows:
-  version: 2
-  main:
+  build-test-and-release:
     jobs:
+      - checkout:
+          filters:
+            tags:
+              only: /^v([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$/
       - build:
           context: staging
+          requires:
+            - checkout
           filters:
             tags:
-              only: /^v\d+\.\d+\.\d+$/
-      - release:
+              only: /^v([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$/
+      - test:
+          context: staging
+          requires:
+            - checkout
+          filters:
+            tags:
+              only: /^v([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$/
+      - publish:
+          context: production
           requires:
             - build
+            - test
           filters:
+            tags:
+              only: /^v([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$/
+            branches:
+              only: master
+      - release:
+          context: production
+          requires:
+            - publish
+          filters:
+            tags:
+              only: /^v([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$/
             branches:
               ignore: /.*/
-            tags:
-              only: /^v\d+\.\d+\.\d+$/

--- a/Makefile
+++ b/Makefile
@@ -47,13 +47,13 @@ release: ## Build release binaries
 	done
 
 test: ## Run unit tests
-	$(GOTEST) -v -timeout 15m -p=1 -cover -coverprofile=c.out $(GIT_REPO)/...
+	$(GOTEST) -v -timeout 20m -p=1 -cover -coverprofile=c.out $(GIT_REPO)/...
 
 coverage: ## Generate code coverage
 	$(GOTOOL) cover -html=c.out -o $(OUTPUT_DIR)$(PACKAGE)-coverage.html
 
 lint: ## Link source files
-	$(GOLINT) $(shell $(GLIDE) novendor)
+	$(GOLINT) -set_exit_status $(shell $(GLIDE) novendor)
 
 vet: ## Vet source files
 	$(GO) vet $(GIT_REPO)/...

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Go Report Card](https://goreportcard.com/badge/github.com/triggermesh/tm)](https://goreportcard.com/report/github.com/triggermesh/tm) [![CircleCI](https://circleci.com/gh/triggermesh/tm/tree/master.svg?style=shield)](https://circleci.com/gh/triggermesh/tm/tree/master)
+[![Release](https://img.shields.io/github/v/release/triggermesh/tm?label=release)](https://github.com/triggermesh/tm/releases) [![Downloads](https://img.shields.io/github/downloads/triggermesh/tm/total?label=downloads)](https://github.com/triggermesh/tm/releases) [![CircleCI](https://circleci.com/gh/triggermesh/tm/tree/master.svg?style=shield)](https://circleci.com/gh/triggermesh/tm/tree/master) [![Go Report Card](https://goreportcard.com/badge/github.com/triggermesh/tm)](https://goreportcard.com/report/github.com/triggermesh/tm) [![License](https://img.shields.io/github/license/triggermesh/tm?label=license)](LICENSE)
 
 A CLI for [knative](https://github.com/knative)
 
@@ -62,7 +62,7 @@ To run tests you first have to set namespace you have access to with the followi
 ```
 export NAMESPACE=yourNamespace
 ```
-Run unit-tests with following command from project root directory: 
+Run unit-tests with following command from project root directory:
 ```
 make test
 ```
@@ -147,9 +147,9 @@ tm push | kubectl apply -f -
 1. Triggermesh Aktion [transceiver](https://github.com/triggermesh/aktion/tree/master/cmd/transceiver) and its configmap to create new taskruns on incoming events from Github containersource
 
 
-\* our Github containersource is aimed at simplifying event tracking and based on periodic Github API requests (one request per minute). As a result, you don't need to create and store any tokens. Downside of this approach is that containersource have requests rate limitation (60 requests per hour) and it doesn't work with private repositories. Both of these limitation can be bypassed by providing Github personal access token in push command parameter: `tm push --token <TOKEN>` 
+\* our Github containersource is aimed at simplifying event tracking and based on periodic Github API requests (one request per minute). As a result, you don't need to create and store any tokens. Downside of this approach is that containersource have requests rate limitation (60 requests per hour) and it doesn't work with private repositories. Both of these limitation can be bypassed by providing Github personal access token in push command parameter: `tm push --token <TOKEN>`
 
-After few minutes you should be able to see new Knative service deployed in cluster. Any commits will trigger new build and deploy so that new function will reflect all code changes.   
+After few minutes you should be able to see new Knative service deployed in cluster. Any commits will trigger new build and deploy so that new function will reflect all code changes.
 
 ### Docker registry
 
@@ -198,7 +198,7 @@ script:
   - tm -n "$KUBE_NAMESPACE" set registry-auth gitlab-registry --registry "$CI_REGISTRY" --username "$CI_DEPLOY_USER" --password "$CI_DEPLOY_PASSWORD" --pull
 ...
 ```
-After this, you may pass `--registry-secret gitlab-registry` parameter to `tm deploy` command (or in [serverless.yml](https://gitlab.com/knative-examples/functions/blob/master/serverless.yaml#L6)) so that Knative could authenticate against Gitlab registry. 
+After this, you may pass `--registry-secret gitlab-registry` parameter to `tm deploy` command (or in [serverless.yml](https://gitlab.com/knative-examples/functions/blob/master/serverless.yaml#L6)) so that Knative could authenticate against Gitlab registry.
 Gitlab registry doesn't provide permanent read-write token that can be used in CI, but it has job-specific `CI_JOB_TOKEN` with "write" permission which is valid only while CI job running and `CI_DEPLOY_PASSWORD` with read permission which we created before. Considering this, we can see that CLI `set registry-auth` command supports `--push` and `--pull` flags that indicates which secret must be used to push image and which for "pull" operations only. Resulting images will be stored under `registry.gitlab.com/username/project/function_name` path
 
 #### Unauthenticated registry

--- a/scripts/release-notes.sh
+++ b/scripts/release-notes.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env sh
+
+RELEASE=${GIT_TAG:-$1}
+
+if [ -z "${RELEASE}" ]; then
+	echo "Usage:"
+	echo "./scripts/release-notes.sh v0.1.0"
+	exit 1
+fi
+
+if ! git rev-list ${RELEASE} >/dev/null 2>&1; then
+	echo "${RELEASE} does not exist"
+	exit
+fi
+
+PREV_RELEASE=${PREV_RELEASE:-$(git describe --tags --abbrev=0 ${RELEASE}^)}
+PREV_RELEASE=${PREV_RELEASE:-$(git rev-list --max-parents=0 ${RELEASE}^)}
+NOTABLE_CHANGES=$(git cat-file -p ${RELEASE} | sed '/-----BEGIN PGP SIGNATURE-----/,//d' | tail -n +6)
+CHANGELOG=$(git log --no-merges --pretty=format:'- [%h] %s (%aN)' ${PREV_RELEASE}..${RELEASE})
+if [ $? -ne 0 ]; then
+	echo "Error creating changelog"
+	exit 1
+fi
+
+cat <<EOF
+${NOTABLE_CHANGES}
+
+## Installation
+
+Download Triggermesh CLI ${RELEASE}
+
+- [container](https://gcr.io/triggermesh/tm:${RELEASE})
+- [linux/amd64](https://github.com/triggermesh/tm/releases/download/${RELEASE}/tm-linux-amd64)
+- [macos/amd64](https://github.com/triggermesh/tm/releases/download/${RELEASE}/tm-darwin-amd64)
+- [windows/amd64](https://github.com/triggermesh/tm/releases/download/${RELEASE}/tm-windows-amd64.exe)
+
+## Changelog
+
+${CHANGELOG}
+EOF


### PR DESCRIPTION
Changes:
- adds `build`, `test`, `publish` and `release` jobs, closes #176
- `build` step tests the `Dockerfile` and `cloudbuild.yaml`, closes #177
- uses circleci orbs (`go and gcp-cli`) for reusable steps
- generates release notes for github-releases with links to assets,
closes #178
- adds README badges
- format README using `prettier` for consistency

Closes #184