### PR TITLE
"project" value added to registry configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,20 @@ script:
 After this, you may pass `--registry-secret gitlab-registry` parameter to `tm deploy` command (or in [serverless.yml](https://gitlab.com/knative-examples/functions/blob/master/serverless.yaml#L6)) so that Knative could authenticate against Gitlab registry.
 Gitlab registry doesn't provide permanent read-write token that can be used in CI, but it has job-specific `CI_JOB_TOKEN` with "write" permission which is valid only while CI job running and `CI_DEPLOY_PASSWORD` with read permission which we created before. Considering this, we can see that CLI `set registry-auth` command supports `--push` and `--pull` flags that indicates which secret must be used to push image and which for "pull" operations only. Resulting images will be stored under `registry.gitlab.com/username/project/function_name` path
 
+### Custom registry name
+
+While using a username as a registry identifier (docker.io/username) is a common practice, in some cases we must be able to use different values for an authentication and in destination URL (for example, [gcr.io](https://cloud.google.com/container-registry/docs/advanced-authentication#linux-macos)). Triggermesh CLI `set registry-auth` command provides such ability by exposing an optional `--project` argument which will be used as a part of the image URL instead of the username:
+
+```
+TOKEN=$(gcloud auth print-access-token)
+tm set registry-auth gcr --registry eu.gcr.io --username oauth2accesstoken --project foo --password $TOKEN
+tm generate python
+tm deploy -f python --registry-secret gcr --wait
+```
+
+As a result, Knative service image will be pushed to `eu.gcr.io/foo/` registry
+
+
 #### Unauthenticated registry
 
 Besides hosted registries, triggermesh CLI may work with unauthenticated registries which does not require setting access credentials. For such cases, you may simply add `--registry-host` argument to deployment command with registry domain name parameter and resulting image will be pushed to `registry-host/namespace/service_name` URL

--- a/README.md
+++ b/README.md
@@ -207,12 +207,12 @@ While using a username as a registry identifier (docker.io/username) is a common
 
 ```
 TOKEN=$(gcloud auth print-access-token)
-tm set registry-auth gcr --registry eu.gcr.io --username oauth2accesstoken --project foo --password $TOKEN
+tm set registry-auth gcr --registry eu.gcr.io --project my-org/my-project --username oauth2accesstoken --password $TOKEN
 tm generate python
 tm deploy -f python --registry-secret gcr --wait
 ```
 
-As a result, Knative service image will be pushed to `eu.gcr.io/foo/` registry
+As a result, Knative service image will be pushed to `eu.gcr.io/my-org/my-project` registry
 
 
 #### Unauthenticated registry

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -49,6 +49,7 @@ func cmdSetRegistryCreds(clientset *client.ConfigSet) *cobra.Command {
 	}
 
 	setRegistryCredsCmd.Flags().StringVar(&rc.Host, "registry", "", "Registry host address")
+	setRegistryCredsCmd.Flags().StringVar(&rc.ProjectID, "project", "", "If set, use this value instead of the username in image URL: <host>/<project>/<image>")
 	setRegistryCredsCmd.Flags().StringVar(&rc.Username, "username", "", "Registry username")
 	setRegistryCredsCmd.Flags().StringVar(&rc.Password, "password", "", "Registry password")
 	setRegistryCredsCmd.Flags().BoolVar(&rc.Pull, "pull", false, "Indicates if this token must be used for pull operations only")

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -49,7 +49,7 @@ func cmdSetRegistryCreds(clientset *client.ConfigSet) *cobra.Command {
 	}
 
 	setRegistryCredsCmd.Flags().StringVar(&rc.Host, "registry", "", "Registry host address")
-	setRegistryCredsCmd.Flags().StringVar(&rc.ProjectID, "project", "", "If set, use this value instead of the username in image URL: <host>/<project>/<image>")
+	setRegistryCredsCmd.Flags().StringVar(&rc.ProjectID, "project", "", "If set, use this value instead of the username in image names. Example: gcr.io/<project>")
 	setRegistryCredsCmd.Flags().StringVar(&rc.Username, "username", "", "Registry username")
 	setRegistryCredsCmd.Flags().StringVar(&rc.Password, "password", "", "Registry password")
 	setRegistryCredsCmd.Flags().BoolVar(&rc.Pull, "pull", false, "Indicates if this token must be used for pull operations only")

--- a/pkg/resources/build/create.go
+++ b/pkg/resources/build/create.go
@@ -404,11 +404,14 @@ func (b *Build) imageName(clientset *client.ConfigSet) (string, error) {
 	if len(config.Auths) > 1 {
 		return "", errors.New("credentials with multiple registries not supported")
 	}
-	for k, v := range config.Auths {
-		if url, ok := gitlabEnv(); ok {
-			return fmt.Sprintf("%s/%s", url, b.Name), nil
+	if url, ok := gitlabEnv(); ok {
+		return fmt.Sprintf("%s/%s", url, b.Name), nil
+	}
+	for host, creds := range config.Auths {
+		if config.Project != "" {
+			return fmt.Sprintf("%s/%s/%s", host, config.Project, b.Name), nil
 		}
-		return fmt.Sprintf("%s/%s/%s", k, v.Username, b.Name), nil
+		return fmt.Sprintf("%s/%s/%s", host, creds.Username, b.Name), nil
 	}
 	return "", errors.New("empty registry credentials")
 }

--- a/pkg/resources/build/types.go
+++ b/pkg/resources/build/types.go
@@ -28,7 +28,8 @@ type Build struct {
 }
 
 type registryAuths struct {
-	Auths registry
+	Project string
+	Auths   registry
 }
 
 type registry map[string]credentials

--- a/pkg/resources/credential/registry-credentials.go
+++ b/pkg/resources/credential/registry-credentials.go
@@ -34,7 +34,7 @@ func (c *RegistryCreds) CreateRegistryCreds(clientset *client.ConfigSet) error {
 			return err
 		}
 	}
-	secret := fmt.Sprintf("{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":\"%s\"}}}", c.Host, c.Username, c.Password)
+	secret := fmt.Sprintf("{\"project\":%q,\"auths\":{%q:{\"username\":%q,\"password\":%q}}}", c.ProjectID, c.Host, c.Username, c.Password)
 	if s, err := clientset.Core.CoreV1().Secrets(c.Namespace).Get(c.Name, metav1.GetOptions{}); err == nil {
 		for k, v := range s.Data {
 			secrets[k] = string(v)

--- a/pkg/resources/credential/types.go
+++ b/pkg/resources/credential/types.go
@@ -25,6 +25,7 @@ type RegistryCreds struct {
 	Name      string
 	Namespace string
 	Host      string
+	ProjectID string
 	Username  string
 	Password  string
 	Pull      bool

--- a/pkg/resources/taskrun/create.go
+++ b/pkg/resources/taskrun/create.go
@@ -310,11 +310,14 @@ func (tr *TaskRun) imageName(clientset *client.ConfigSet) (string, error) {
 	if len(config.Auths) > 1 {
 		return "", errors.New("credentials with multiple registries not supported")
 	}
-	for k, v := range config.Auths {
-		if url, ok := gitlabEnv(); ok {
-			return fmt.Sprintf("%s/%s", url, tr.Name), nil
+	if url, ok := gitlabEnv(); ok {
+		return fmt.Sprintf("%s/%s", url, tr.Name), nil
+	}
+	for host, creds := range config.Auths {
+		if config.Project != "" {
+			return fmt.Sprintf("%s/%s/%s", host, config.Project, tr.Name), nil
 		}
-		return fmt.Sprintf("%s/%s/%s", k, v.Username, tr.Name), nil
+		return fmt.Sprintf("%s/%s/%s", host, creds.Username, tr.Name), nil
 	}
 	return "", errors.New("empty registry credentials")
 }

--- a/pkg/resources/taskrun/types.go
+++ b/pkg/resources/taskrun/types.go
@@ -41,7 +41,8 @@ type Source struct {
 }
 
 type registryAuths struct {
-	Auths registry
+	Project string
+	Auths   registry
 }
 
 type credentials struct {


### PR DESCRIPTION
Configure destination URL by setting optional `project` value in `set registry-auth` command:

```
tm set registry-auth gcr --registry eu.gcr.io --username oauth2accesstoken --project foo
```

See README update below