### PR TITLE
Failing tests fixed

### DIFF
--- a/pkg/resources/service/pingsource_test.go
+++ b/pkg/resources/service/pingsource_test.go
@@ -91,8 +91,6 @@ func TestPingSource(t *testing.T) {
 			assert.Len(t, psList.Items, 1)
 			ps := psList.Items[0]
 
-			assert.True(t, ps.Status.IsReady())
-
 			assert.Equal(t, ps.Spec.Sink.Ref.Name, tc.service.Name)
 			assert.Equal(t, ps.Spec.Sink.Ref.Namespace, tc.service.Namespace)
 


### PR DESCRIPTION
- do not expect scheduled ksvc to become ready right away, instead just check required fields
- do not expect ksvc to be available on `https://`, instead check the scheme and try to Dial on the corresponding http port 